### PR TITLE
HashFS deep scan: parallel path search, timing metrics, dry-run + CLI

### DIFF
--- a/Extractor.Tests/HashFsExtractorTest.cs
+++ b/Extractor.Tests/HashFsExtractorTest.cs
@@ -12,13 +12,14 @@ namespace Extractor.Tests
         [Fact]
         public void DeterminePathSubstitutions()
         {
+            PathUtils.ResetNameCounter();
             List<string> paths = [
                 "/bla?.txt",
                 "/def/country.sii"
                 ];
             var actual = HashFsExtractor.DeterminePathSubstitutions(paths);
             Assert.Single(actual);
-            Assert.Equal("/blax3F.txt", actual["/bla?.txt"]);
+            Assert.Matches("^/F\\d{8}\\.txt$", actual["/bla?.txt"]);
         }
 
         [Fact]

--- a/Extractor.Tests/PathUtilsTest.cs
+++ b/Extractor.Tests/PathUtilsTest.cs
@@ -25,6 +25,7 @@ namespace Extractor.Tests
         [Fact]
         public void ReplaceCharsUnambiguously()
         {
+            // Below 10% threshold, per-char replacement should be legacy hex (xNN)
             Assert.Equal("ax3Cbcx3Ed", PathUtils.ReplaceCharsUnambiguously("a<bc>d", ['<', '>']));
             Assert.Equal("", PathUtils.ReplaceCharsUnambiguously("", ['x']));
         }
@@ -108,6 +109,7 @@ namespace Extractor.Tests
         [Fact]
         public void SanitizePath()
         {
+            PathUtils.ResetNameCounter();
             char[] invalidOnWindows = new char[] {
                 '\"', '<', '>', '|', ':', '*', '?',
                 '\0', '\u0001', '\u0002', '\u0003', '\u0004', '\u0005', '\u0006',
@@ -119,7 +121,7 @@ namespace Extractor.Tests
             Assert.Equal("no/changes/äöü.txt", 
                 PathUtils.SanitizePath("no/changes/äöü.txt", invalidOnWindows));
 
-            Assert.Equal("x2A_x3F.pmd", 
+            Assert.Equal("F00000000.pmd", 
                 PathUtils.SanitizePath("*_?.pmd", invalidOnWindows));
             Assert.Equal("*_?.pmd",
                 PathUtils.SanitizePath("*_?.pmd", ['\0'], false));
@@ -132,7 +134,8 @@ namespace Extractor.Tests
             Assert.Equal("/aux/hello/LPT1.sii",
                 PathUtils.SanitizePath("/aux/hello/LPT1.sii", ['\0'], false));
 
-            Assert.Equal("/vehiclex200B",
+            PathUtils.ResetNameCounter();
+            Assert.Equal("/F00000000",
                 PathUtils.SanitizePath("/vehicle\u200b"));
         }
 
@@ -141,6 +144,141 @@ namespace Extractor.Tests
         {
             Assert.Equal("/a/b/c42.txt", PathUtils.AppendBeforeExtension("/a/b/c.txt", "42"));
             Assert.Equal("/a/b/c42", PathUtils.AppendBeforeExtension("/a/b/c", "42"));
+        }
+
+        [Fact]
+        public void RemoveNonAsciiOrInvalidChars_PreservesUnicodeLetters()
+        {
+            var input = "/straße/größe/äöüß.txt"; // contains ß and umlauts
+            var actual = PathUtils.RemoveNonAsciiOrInvalidChars(input);
+            Assert.Equal(input, actual);
+        }
+
+        [Fact]
+        public void RemoveNonAsciiOrInvalidChars_RemovesProblematic()
+        {
+            var input = "/veh\u200Bicle*?.txt"; // zero-width space + invalid filename chars
+            var actual = PathUtils.RemoveNonAsciiOrInvalidChars(input);
+            Assert.Equal("/vehicle.txt", actual);
+        }
+
+        [Fact]
+        public void LegacyReplacement_PerCharHex()
+        {
+            // Validate legacy per-char hex replacement via ReplaceCharsUnambiguously
+            // (independent from global LegacyReplaceMode state)
+            char[] invalidOnWindows = new char[] {
+                '\"', '<', '>', '|', ':', '*', '?',
+                '\0', '\u0001', '\u0002', '\u0003', '\u0004', '\u0005', '\u0006',
+                '\a', '\b', '\t', '\n', '\v', '\f', '\r', '\u000e', '\u000f',
+                '\u0010', '\u0011', '\u0012', '\u0013', '\u0014', '\u0015', '\u0016', '\u0017',
+                '\u0018', '\u0019', '\u001a', '\u001b', '\u001c', '\u001d', '\u001e', '\u001f'
+                }.Order().ToArray();
+
+            Assert.Equal("x2A_x3F.pmd",
+                PathUtils.ReplaceCharsUnambiguously("*_?.pmd", invalidOnWindows));
+
+            Assert.Equal("/vehiclex200B",
+                PathUtils.ReplaceCharsUnambiguously("/vehicle\u200b", PathUtils.InvalidPathChars));
+        }
+
+        [Fact]
+        public void DirectorySegment_RenamesToDWithThreshold()
+        {
+            PathUtils.ResetNameCounter();
+            char[] invalidOnWindows = new char[] {
+                '\"', '<', '>', '|', ':', '*', '?',
+                '\0', '\u0001', '\u0002', '\u0003', '\u0004', '\u0005', '\u0006',
+                '\a', '\b', '\t', '\n', '\v', '\f', '\r', '\u000e', '\u000f',
+                '\u0010', '\u0011', '\u0012', '\u0013', '\u0014', '\u0015', '\u0016', '\u0017',
+                '\u0018', '\u0019', '\u001a', '\u001b', '\u001c', '\u001d', '\u001e', '\u001f'
+                }.Order().ToArray();
+            var actual = PathUtils.SanitizePath("/:???/abc.txt", invalidOnWindows);
+            Assert.Matches("^/D\\d{8}/abc\\.txt$", actual);
+        }
+
+        [Fact]
+        public void DirectoryAndFile_ShareSameIdForEqualKey()
+        {
+            PathUtils.ResetNameCounter();
+            char[] invalidOnWindows = new char[] {
+                '\"', '<', '>', '|', ':', '*', '?',
+                '\0', '\u0001', '\u0002', '\u0003', '\u0004', '\u0005', '\u0006',
+                '\a', '\b', '\t', '\n', '\v', '\f', '\r', '\u000e', '\u000f',
+                '\u0010', '\u0011', '\u0012', '\u0013', '\u0014', '\u0015', '\u0016', '\u0017',
+                '\u0018', '\u0019', '\u001a', '\u001b', '\u001c', '\u001d', '\u001e', '\u001f'
+                }.Order().ToArray();
+            var actual = PathUtils.SanitizePath("/???/???.txt", invalidOnWindows);
+            // Expect /D########/F########.txt with same number
+            var parts = actual.Split('/');
+            Assert.Equal(3, parts.Length);
+            Assert.Matches("^D\\d{8}$", parts[1]);
+            Assert.Matches("^F\\d{8}\\.txt$", parts[2]);
+            var dNum = int.Parse(parts[1].Substring(1, 8));
+            var fNum = int.Parse(parts[2].Substring(1, 8));
+            Assert.Equal(dNum, fNum);
+        }
+
+        [Fact]
+        public void DirectorySameNameAcrossPaths_ShareSameId()
+        {
+            PathUtils.ResetNameCounter();
+            char[] invalidOnWindows = new char[] {
+                '\"', '<', '>', '|', ':', '*', '?',
+                '\0', '\u0001', '\u0002', '\u0003', '\u0004', '\u0005', '\u0006',
+                '\a', '\b', '\t', '\n', '\v', '\f', '\r', '\u000e', '\u000f',
+                '\u0010', '\u0011', '\u0012', '\u0013', '\u0014', '\u0015', '\u0016', '\u0017',
+                '\u0018', '\u0019', '\u001a', '\u001b', '\u001c', '\u001d', '\u001e', '\u001f'
+                }.Order().ToArray();
+            var a = PathUtils.SanitizePath("/:??/a.txt", invalidOnWindows);
+            var b = PathUtils.SanitizePath("/:??/b.txt", invalidOnWindows);
+            var aDir = a.Split('/')[1];
+            var bDir = b.Split('/')[1];
+            Assert.Matches("^D\\d{8}$", aDir);
+            Assert.Matches("^D\\d{8}$", bDir);
+            Assert.Equal(aDir, bDir);
+        }
+
+        [Fact]
+        public void FileSameBaseAcrossPaths_ShareSameId()
+        {
+            PathUtils.ResetNameCounter();
+            char[] invalidOnWindows = new char[] {
+                '\"', '<', '>', '|', ':', '*', '?',
+                '\0', '\u0001', '\u0002', '\u0003', '\u0004', '\u0005', '\u0006',
+                '\a', '\b', '\t', '\n', '\v', '\f', '\r', '\u000e', '\u000f',
+                '\u0010', '\u0011', '\u0012', '\u0013', '\u0014', '\u0015', '\u0016', '\u0017',
+                '\u0018', '\u0019', '\u001a', '\u001b', '\u001c', '\u001d', '\u001e', '\u001f'
+                }.Order().ToArray();
+            var a = PathUtils.SanitizePath("/x/???.txt", invalidOnWindows);
+            var b = PathUtils.SanitizePath("/y/???.dds", invalidOnWindows);
+            var aFile = a.Split('/')[2];
+            var bFile = b.Split('/')[2];
+            Assert.Matches("^F\\d{8}\\.txt$", aFile);
+            Assert.Matches("^F\\d{8}\\.dds$", bFile);
+            var aNum = int.Parse(aFile.Substring(1, 8));
+            var bNum = int.Parse(bFile.Substring(1, 8));
+            Assert.Equal(aNum, bNum);
+        }
+
+        [Fact]
+        public void NameCounter_IsGlobalAndSequential()
+        {
+            // Don't depend on exact values; only monotonic sequence and format
+            string a = PathUtils.SanitizePath("a?b.txt");
+            string b = PathUtils.SanitizePath("c*d.txt");
+            string c = PathUtils.SanitizePath("/e|f.sii");
+
+            Assert.Matches("^F\\d{8}\\.txt$", a);
+            Assert.Matches("^F\\d{8}\\.txt$", b);
+            Assert.Matches("^/F\\d{8}\\.sii$", c);
+
+            int na = int.Parse(a.Substring(1, 8));
+            int nb = int.Parse(b.Substring(1, 8));
+            int nc = int.Parse(c.Substring(2, 8));
+
+            Assert.True(na < nb);
+            Assert.True(nb < nc);
         }
     }
 }

--- a/Extractor.Tests/Zip/ZipExtractorTest.cs
+++ b/Extractor.Tests/Zip/ZipExtractorTest.cs
@@ -33,10 +33,11 @@ namespace Extractor.Tests.Zip
         [Fact]
         public void DeterminePathSubstitutions()
         {
+            PathUtils.ResetNameCounter();
             var zip = ZipReader.Open("Data/ZipExtractorTest/test.zip");
             var entries = ZipExtractor.GetEntriesToExtract(zip, ["/"]);
             var subst = ZipExtractor.DeterminePathSubstitutions(entries);
-            Assert.Equal("blax3F.txt", subst["bla?.txt"]);
+            Assert.Matches("^F\\d{8}\\.txt$", subst["bla?.txt"]);
         }
     }
 }

--- a/Extractor/Deep/HashFsDeepExtractor.cs
+++ b/Extractor/Deep/HashFsDeepExtractor.cs
@@ -110,18 +110,15 @@ namespace Extractor.Deep
                 finder = new HashFsPathFinder(Reader, AdditionalStartPaths, junkEntries,
                     SingleThreadedPathSearch, CreateReaderClone, ReaderPoolSize);
                 finder.Find();
-                if (PrintTimesEnabled)
-                {
-                    // Populate detailed timing metrics
-                    SearchExtractTime = finder.ExtractTime;
-                    SearchParseTime = finder.ParseTime;
-                    SearchFilesParsed = finder.FilesParsed;
-                    SearchBytesInflated = finder.BytesInflated;
-                    SearchExtractWallTime = finder.ExtractWallTime;
-                    // Report unique as the number of unique discovered files (stable across ST/MT)
-                    SearchUniqueFilesParsed = finder.FoundFiles?.Count;
-                    SearchTime = (finder.ExtractTime + finder.ParseTime);
-                }
+                // Always populate detailed timing/metric fields for downstream reporting
+                SearchExtractTime = finder.ExtractTime;
+                SearchParseTime = finder.ParseTime;
+                SearchFilesParsed = finder.FilesParsed;
+                SearchBytesInflated = finder.BytesInflated;
+                SearchExtractWallTime = finder.ExtractWallTime;
+                // Report unique as the number of unique discovered files (stable across ST/MT)
+                SearchUniqueFilesParsed = finder.FoundFiles?.Count;
+                SearchTime = (finder.ExtractTime + finder.ParseTime);
                 hasSearchedForPaths = true;
             }
             return (finder.FoundFiles, finder.ReferencedFiles);

--- a/Extractor/Deep/HashFsDeepExtractor.cs
+++ b/Extractor/Deep/HashFsDeepExtractor.cs
@@ -21,6 +21,14 @@ namespace Extractor.Deep
     public class HashFsDeepExtractor : HashFsExtractor
     {
         /// <summary>
+        /// If true, perform path search in a single thread.
+        /// </summary>
+        public bool SingleThreadedPathSearch { get; set; } = false;
+        /// <summary>
+        /// Number of parallel readers to use for deep search. Default: logical CPU count.
+        /// </summary>
+        public int ReaderPoolSize { get; set; } = Math.Max(1, Environment.ProcessorCount);
+        /// <summary>
         /// Additional start paths which the user specified with the <c>--additional</c> parameter.
         /// </summary>
         public IList<string> AdditionalStartPaths { get; set; } = [];
@@ -99,8 +107,18 @@ namespace Extractor.Deep
         {
             if (!hasSearchedForPaths)
             {
-                finder = new HashFsPathFinder(Reader, AdditionalStartPaths, junkEntries);
+                finder = new HashFsPathFinder(Reader, AdditionalStartPaths, junkEntries,
+                    SingleThreadedPathSearch, CreateReaderClone, ReaderPoolSize);
                 finder.Find();
+                // Populate detailed timing metrics
+                SearchExtractTime = finder.ExtractTime;
+                SearchParseTime = finder.ParseTime;
+                SearchFilesParsed = finder.FilesParsed;
+                SearchBytesInflated = finder.BytesInflated;
+                SearchExtractWallTime = finder.ExtractWallTime;
+                // Report unique as the number of unique discovered files (stable across ST/MT)
+                SearchUniqueFilesParsed = finder.FoundFiles?.Count;
+                SearchTime = (finder.ExtractTime + finder.ParseTime);
                 hasSearchedForPaths = true;
             }
             return (finder.FoundFiles, finder.ReferencedFiles);
@@ -113,6 +131,9 @@ namespace Extractor.Deep
         /// <param name="foundFiles">All discovered paths.</param>
         private void DumpUnrecovered(string destination, IEnumerable<string> foundFiles)
         {
+            if (DryRun)
+                return;
+
             var notRecovered = Reader.Entries.Values
                 .Where(e => !e.IsDirectory)
                 .Except(foundFiles.Select(f =>
@@ -157,10 +178,13 @@ namespace Extractor.Deep
 
         public override void PrintPaths(IList<string> pathFilter, bool includeAll)
         {
-            var finder = new HashFsPathFinder(Reader);
+            var finder = new HashFsPathFinder(Reader,
+                singleThreaded: SingleThreadedPathSearch,
+                readerFactory: CreateReaderClone,
+                readerPoolSize: ReaderPoolSize);
             finder.Find();
-            var paths = (includeAll 
-                ? finder.FoundFiles.Union(finder.ReferencedFiles) 
+            var paths = (includeAll
+                ? finder.FoundFiles.Union(finder.ReferencedFiles)
                 : finder.FoundFiles).Order();
 
             foreach (var path in paths)
@@ -171,15 +195,26 @@ namespace Extractor.Deep
 
         public override void PrintExtractionResult()
         {
+            var times = (OpenTime.HasValue || SearchTime.HasValue || ExtractTime.HasValue)
+                ? $" | open={OpenTime?.TotalMilliseconds:F0}ms, " +
+                  $"search={SearchTime?.TotalMilliseconds:F0}ms" +
+                  (SearchExtractTime.HasValue || SearchParseTime.HasValue || SearchFilesParsed.HasValue || SearchBytesInflated.HasValue
+                    ? $" (decomp={SearchExtractTime?.TotalMilliseconds:F0}ms, decomp_wall={SearchExtractWallTime?.TotalMilliseconds:F0}ms, parse={SearchParseTime?.TotalMilliseconds:F0}ms, files={SearchFilesParsed?.ToString() ?? "-"}, unique={SearchUniqueFilesParsed?.ToString() ?? "-"}, bytes={SearchBytesInflated?.ToString() ?? "-"})"
+                    : string.Empty)
+                  + $", extract={ExtractTime?.TotalMilliseconds:F0}ms"
+                : string.Empty;
             Console.WriteLine($"{extracted} extracted " +
                 $"({renamedFiles.Count} renamed, {modifiedFiles.Count} modified, {dumped} dumped), " +
-                $"{skipped} skipped, {duplicate} junk, {failed} failed");
+                $"{skipped} skipped, {duplicate} junk, {failed} failed" + times);
             PrintRenameSummary(renamedFiles.Count, modifiedFiles.Count);
         }
 
         public override List<Tree.Directory> GetDirectoryTree(IList<string> pathFilter)
         {
-            var finder = new HashFsPathFinder(Reader);
+            var finder = new HashFsPathFinder(Reader,
+                singleThreaded: SingleThreadedPathSearch,
+                readerFactory: CreateReaderClone,
+                readerPoolSize: ReaderPoolSize);
             finder.Find();
 
             var trees = pathFilter
@@ -187,5 +222,13 @@ namespace Extractor.Deep
                 .ToList();
             return trees;
         }
+
+        private TruckLib.HashFs.IHashFsReader CreateReaderClone()
+        {
+            var r = TruckLib.HashFs.HashFsReader.Open(ScsPath, ForceEntryTableAtEnd);
+            r.Salt = Reader.Salt;
+            return r;
+        }
     }
 }
+

--- a/Extractor/Deep/HashFsPathFinder.cs
+++ b/Extractor/Deep/HashFsPathFinder.cs
@@ -2,6 +2,7 @@
 using Sprache;
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
@@ -82,12 +83,66 @@ namespace Extractor.Deep
         /// </summary>
         private readonly HashSet<string> dirsToSearchForRelativeTobj;
 
-        public HashFsPathFinder(IHashFsReader reader, IList<string> additionalStartPaths = null, 
-            Dictionary<ulong, IEntry> junkEntries = null)
+        // Synchronization primitives for thread-safety
+        private readonly object visitedLock = new();
+        private readonly object visitedEntriesLock = new();
+        private readonly object referencedFilesLock = new();
+        private readonly object dirsLock = new();
+        private readonly object foundFilesLock = new();
+        private readonly object junkEntriesLock = new();
+        private readonly object readerLock = new();
+
+        // Reader pool for parallel, safe extraction
+        private readonly Func<IHashFsReader> readerFactory;
+        private readonly int readerPoolSize;
+        private System.Collections.Concurrent.ConcurrentBag<IHashFsReader> readerPool;
+        private System.Collections.Concurrent.ConcurrentDictionary<IHashFsReader, byte> readerPoolMembers;
+        private System.Threading.SemaphoreSlim readerSemaphore;
+
+        // Timing/metrics (ticks accumulated across threads)
+        private long extractTicks = 0;
+        private long parseTicks = 0;
+        private int filesParsed = 0;
+        private long bytesInflated = 0;
+        private long decompWallStartTs = 0;
+        private long decompWallEndTs = 0;
+        private readonly object decompWallLock = new();
+        private readonly System.Collections.Concurrent.ConcurrentDictionary<string, byte> uniqueParsed = new();
+
+        public TimeSpan ExtractTime => TimeSpan.FromTicks(System.Threading.Interlocked.Read(ref extractTicks));
+        public TimeSpan ParseTime => TimeSpan.FromTicks(System.Threading.Interlocked.Read(ref parseTicks));
+        public int FilesParsed => System.Threading.Interlocked.CompareExchange(ref filesParsed, 0, 0);
+        public long BytesInflated => System.Threading.Interlocked.Read(ref bytesInflated);
+        public TimeSpan ExtractWallTime
+        {
+            get
+            {
+                var start = System.Threading.Interlocked.Read(ref decompWallStartTs);
+                var end = System.Threading.Interlocked.Read(ref decompWallEndTs);
+                if (start == 0 || end <= start) return TimeSpan.Zero;
+                double ticks = (end - start);
+                double seconds = ticks / (double)Stopwatch.Frequency;
+                return TimeSpan.FromSeconds(seconds);
+            }
+        }
+        public int UniqueFilesParsed => uniqueParsed.Count;
+
+        private readonly bool singleThreaded;
+
+        public HashFsPathFinder(
+            IHashFsReader reader,
+            IList<string> additionalStartPaths = null,
+            Dictionary<ulong, IEntry> junkEntries = null,
+            bool singleThreaded = false,
+            Func<IHashFsReader> readerFactory = null,
+            int readerPoolSize = 1)
         {
             this.reader = reader;
             this.additionalStartPaths = additionalStartPaths;
             this.junkEntries = junkEntries ?? [];
+            this.singleThreaded = singleThreaded;
+            this.readerFactory = readerFactory;
+            this.readerPoolSize = Math.Max(1, readerPoolSize);
 
             visited = [];
             visitedEntries = [];
@@ -95,7 +150,7 @@ namespace Extractor.Deep
             dirsToSearchForRelativeTobj = [];
             ReferencedFiles = [];
 
-            fpf = new FilePathFinder(visited, ReferencedFiles, dirsToSearchForRelativeTobj, reader);
+            fpf = new FilePathFinder(ReferencedFiles, dirsToSearchForRelativeTobj, reader, referencedFilesLock, dirsLock);
         }
 
         /// <summary>
@@ -104,6 +159,7 @@ namespace Extractor.Deep
         /// </summary>
         public void Find()
         {
+            InitializeReaderPool();
             var potentialPaths = LoadStartPaths();
             if (additionalStartPaths is not null)
                 potentialPaths.UnionWith(additionalStartPaths);
@@ -113,6 +169,84 @@ namespace Extractor.Deep
             ExplorePotentialPaths(morePaths);
 
             FoundDecoyFiles = FindDecoyPaths();
+
+            DisposeReaderPool();
+        }
+
+        private void InitializeReaderPool()
+        {
+            if (singleThreaded)
+                return;
+            if (readerFactory is null || readerPoolSize <= 1)
+                return;
+            readerSemaphore = new System.Threading.SemaphoreSlim(readerPoolSize, readerPoolSize);
+            readerPool = new System.Collections.Concurrent.ConcurrentBag<IHashFsReader>();
+            readerPoolMembers = new System.Collections.Concurrent.ConcurrentDictionary<IHashFsReader, byte>();
+            for (int i = 0; i < readerPoolSize; i++)
+            {
+                try
+                {
+                    var r = readerFactory();
+                    readerPool.Add(r);
+                    readerPoolMembers.TryAdd(r, 0);
+                }
+                catch
+                {
+                    // Fall back to fewer readers if creation fails
+                    break;
+                }
+            }
+        }
+
+        private IHashFsReader AcquireReader()
+        {
+            if (readerPool is null)
+                return null;
+            readerSemaphore.Wait();
+            if (readerPool.TryTake(out var r))
+                return r;
+            // Shouldn't happen, but create a temporary reader if factory available
+            return readerFactory?.Invoke();
+        }
+
+        private void ReleaseReader(IHashFsReader r)
+        {
+            if (readerSemaphore is null)
+                return;
+
+            try
+            {
+                if (r is not null && readerPool is not null && readerPoolMembers is not null && readerPoolMembers.ContainsKey(r))
+                {
+                    readerPool.Add(r);
+                }
+                else
+                {
+                    try { r?.Dispose(); } catch { }
+                }
+            }
+            finally
+            {
+                try { readerSemaphore.Release(); } catch { }
+            }
+        }
+
+        private void DisposeReaderPool()
+        {
+            if (readerPool is null)
+                return;
+            while (readerPool.TryTake(out var r))
+            {
+                try { r.Dispose(); } catch { }
+                if (readerPoolMembers is not null)
+                {
+                    readerPoolMembers.TryRemove(r, out _);
+                }
+            }
+            readerSemaphore?.Dispose();
+            readerSemaphore = null;
+            readerPool = null;
+            readerPoolMembers = null;
         }
 
         /// <summary>
@@ -145,78 +279,218 @@ namespace Extractor.Deep
         /// <returns>Newly discovered paths.</returns>
         private PotentialPaths FindPathsInUnvisited()
         {
-            PotentialPaths potentialPaths = [];
-
-            var unvisited = reader.Entries.Values.Except(visitedEntries);
-            foreach (var entry in unvisited)
+            if (singleThreaded)
             {
-                visitedEntries.Add(entry);
-                
-                if (junkEntries.ContainsKey(entry.Hash))
+                // Sequential/legacy behavior with consistent metrics
+                PotentialPaths potentialPaths = [];
+                var unvisited = reader.Entries.Values.Except(visitedEntries);
+                foreach (var entry in unvisited)
                 {
-                    continue;
-                }
+                    visitedEntries.Add(entry);
+                    if (junkEntries.ContainsKey(entry.Hash))
+                        continue;
+                    if (entry.IsDirectory)
+                        continue;
+                    if (entry is EntryV2 v2 && v2.TobjMetadata is not null)
+                        continue;
 
-                if (entry.IsDirectory)
-                {
-                    continue;
-                }
-                if (entry is EntryV2 v2 && v2.TobjMetadata is not null)
-                {
-                    continue;
-                }
-
-                byte[] fileBuffer;
-                try
-                {
-                    fileBuffer = reader.Extract(entry, "")[0];
-                }
-                catch (InvalidDataException)
-                {
-                    #if DEBUG
-                        Console.WriteLine($"Unable to decompress, likely junk: {entry.Hash:X16}");
-                    #endif
-                    junkEntries.TryAdd(entry.Hash, entry);
-                    continue;
-                }
-                catch (Exception)
-                {
-                    #if DEBUG
-                        Debugger.Break();
-                    #endif
-                    continue;
-                }
-
-                var type = FileTypeHelper.Infer(fileBuffer);
-                if (type == FileType.Material)
-                {
-                    // The file path of automats is derived from the CityHash64 of its content,
-                    // so we add this automat path to the set of paths to check
-                    var contentHash = CityHash.CityHash64(fileBuffer, (ulong)fileBuffer.Length);
-                    var contentHashStr = contentHash.ToString("x16");
-                    var automatPath = $"/automat/{contentHashStr[..2]}/{contentHashStr}.mat";
-                    potentialPaths.Add(automatPath);
-                }
-                try
-                {
-                    var paths = fpf.FindPathsInFile(fileBuffer, null, type);
-                    foreach (var path in paths)
+                    byte[] fileBuffer;
+                    try
                     {
-                        potentialPaths.Add(path, visited);
+                        var swExt = Stopwatch.StartNew();
+                        lock (readerLock)
+                        {
+                            MarkDecompWallStart();
+                            fileBuffer = reader.Extract(entry, "")[0];
+                            MarkDecompWallEnd();
+                        }
+                        swExt.Stop();
+                        System.Threading.Interlocked.Add(ref extractTicks, swExt.ElapsedTicks);
+                        System.Threading.Interlocked.Add(ref bytesInflated, fileBuffer.LongLength);
+                    }
+                    catch (InvalidDataException)
+                    {
+                        #if DEBUG
+                            Console.WriteLine($"Unable to decompress, likely junk: {entry.Hash:X16}");
+                        #endif
+                        junkEntries.TryAdd(entry.Hash, entry);
+                        continue;
+                    }
+                    catch (Exception)
+                    {
+                        #if DEBUG
+                            Debugger.Break();
+                        #endif
+                        continue;
+                    }
+
+                    var type = FileTypeHelper.Infer(fileBuffer);
+                    if (type == FileType.Material)
+                    {
+                        // The file path of automats is derived from the CityHash64 of its content.
+                        var contentHash = CityHash.CityHash64(fileBuffer, (ulong)fileBuffer.Length);
+                        var contentHashStr = contentHash.ToString("x16");
+                        var automatPath = $"/automat/{contentHashStr[..2]}/{contentHashStr}.mat";
+                        potentialPaths.Add(automatPath);
+                    }
+                    try
+                    {
+                        var swParse = Stopwatch.StartNew();
+                        var paths = fpf.FindPathsInFile(fileBuffer, null, type);
+                        swParse.Stop();
+                        System.Threading.Interlocked.Add(ref parseTicks, swParse.ElapsedTicks);
+                        System.Threading.Interlocked.Increment(ref filesParsed);
+                        uniqueParsed.TryAdd(entry.Hash.ToString("x16"), 0);
+
+                        // Expand variants to keep behavior consistent with parallel branch
+                        PotentialPaths expanded = [];
+                        foreach (var path in paths)
+                        {
+                            expanded.AddWithVariants(path);
+                        }
+                        foreach (var p in expanded)
+                        {
+                            potentialPaths.Add(p, visited);
+                        }
+                    }
+                    #if DEBUG
+                    catch (Exception ex)
+                    #else
+                    catch (Exception)
+                    #endif
+                    {
+                        #if DEBUG
+                            var extension = FileTypeHelper.FileTypeToExtension(type);
+                            Console.Error.WriteLine($"Unable to parse {entry.Hash:X16}{extension}: " +
+                                $"{ex.GetType().Name}: {ex.Message}");
+                        #endif
+                        continue;
                     }
                 }
-                catch (Exception ex)
-                {
-                    #if DEBUG
-                        var extension = FileTypeHelper.FileTypeToExtension(type);
-                        Console.Error.WriteLine($"Unable to parse {entry.Hash:X16}{extension}: " +
-                            $"{ex.GetType().Name}: {ex.Message}");
-                    #endif
-                    continue;
-                }
+                return potentialPaths;
             }
+            else
+            {
+                var bag = new ConcurrentBag<string>();
+                var unvisited = reader.Entries.Values.Except(visitedEntries).ToList();
+                Parallel.ForEach(unvisited, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, entry =>
+                {
+                    lock (visitedEntriesLock)
+                    {
+                        visitedEntries.Add(entry);
+                    }
+                    lock (junkEntriesLock)
+                    {
+                        if (junkEntries.ContainsKey(entry.Hash))
+                        {
+                            return;
+                        }
+                    }
+                    if (entry.IsDirectory)
+                    {
+                        return;
+                    }
+                    if (entry is EntryV2 v2 && v2.TobjMetadata is not null)
+                    {
+                        return;
+                    }
 
-            return potentialPaths;
+                    byte[] fileBuffer;
+                    try
+                    {
+                        var swExt = Stopwatch.StartNew();
+                        if (readerPool is null)
+                        {
+                            lock (readerLock)
+                            {
+                                fileBuffer = reader.Extract(entry, "")[0];
+                            }
+                        }
+                        else
+                        {
+                            IHashFsReader r = null;
+                            try
+                            {
+                                r = AcquireReader();
+                                MarkDecompWallStart();
+                                fileBuffer = r.Extract(entry, "")[0];
+                                MarkDecompWallEnd();
+                            }
+                            finally
+                            {
+                                ReleaseReader(r);
+                            }
+                        }
+                        swExt.Stop();
+                        System.Threading.Interlocked.Add(ref extractTicks, swExt.ElapsedTicks);
+                        System.Threading.Interlocked.Add(ref bytesInflated, fileBuffer.LongLength);
+                    }
+                    catch (InvalidDataException)
+                    {
+                        #if DEBUG
+                            Console.WriteLine($"Unable to decompress, likely junk: {entry.Hash:X16}");
+                        #endif
+                        lock (junkEntriesLock)
+                        {
+                            if (!junkEntries.ContainsKey(entry.Hash))
+                                junkEntries[entry.Hash] = entry;
+                        }
+                        return;
+                    }
+                    catch (Exception)
+                    {
+                        #if DEBUG
+                            Debugger.Break();
+                        #endif
+                        return;
+                    }
+
+                    var type = FileTypeHelper.Infer(fileBuffer);
+                    if (type == FileType.Material)
+                    {
+                        // The file path of automats is derived from the CityHash64 of its content,
+                        // so we add this automat path to the set of paths to check
+                        var contentHash = CityHash.CityHash64(fileBuffer, (ulong)fileBuffer.Length);
+                        var contentHashStr = contentHash.ToString("x16");
+                        var automatPath = $"/automat/{contentHashStr[..2]}/{contentHashStr}.mat";
+                        bag.Add(automatPath);
+                    }
+                try
+                {
+                    var swParse = Stopwatch.StartNew();
+                    var paths = fpf.FindPathsInFile(fileBuffer, null, type);
+                    swParse.Stop();
+                    System.Threading.Interlocked.Add(ref parseTicks, swParse.ElapsedTicks);
+                    System.Threading.Interlocked.Increment(ref filesParsed);
+                    uniqueParsed.TryAdd(entry.Hash.ToString("x16"), 0);
+
+                    // Ensure variant expansion is applied (e.g., .mat <-> .tobj/.dds)
+                    PotentialPaths expanded = [];
+                    foreach (var path in paths)
+                    {
+                        expanded.AddWithVariants(path);
+                    }
+                    foreach (var p in expanded)
+                    {
+                        bag.Add(p);
+                    }
+                }
+                    #if DEBUG
+                    catch (Exception ex)
+                    #else
+                    catch (Exception)
+                    #endif
+                    {
+                        #if DEBUG
+                            var extension = FileTypeHelper.FileTypeToExtension(type);
+                            Console.Error.WriteLine($"Unable to parse {entry.Hash:X16}{extension}: " +
+                                $"{ex.GetType().Name}: {ex.Message}");
+                        #endif
+                        return;
+                    }
+                });
+                return new PotentialPaths(bag);
+            }
         }
 
         /// <summary>
@@ -259,42 +533,78 @@ namespace Extractor.Deep
         /// <returns>The discovered potential paths.</returns>
         private PotentialPaths FindPaths(PotentialPaths inputPaths)
         {
-            PotentialPaths potentialPaths = [];
+            // Collect files to process first, then process them in parallel using the reader pool.
+            HashSet<string> filesToProcess = [];
+
             foreach (var path in inputPaths)
             {
-                if (visited.Contains(path))
-                    continue;
+                lock (visitedLock)
+                {
+                    if (visited.Contains(path))
+                        continue;
+                }
 
                 reader.Traverse(path,
-                    (dir) => 
+                    (dir) =>
                     {
-                        var isNew = visited.Add(dir);
-                        if (isNew)
+                        bool isNew;
+                        lock (visitedLock)
                         {
-                            visitedEntries.Add(reader.GetEntry(dir));
+                            isNew = visited.Add(dir);
+                            if (isNew)
+                            {
+                                lock (visitedEntriesLock)
+                                {
+                                    visitedEntries.Add(reader.GetEntry(dir));
+                                }
+                            }
                         }
                         return isNew;
                     },
                     (file) =>
                     {
-                        try
+                        // Avoid scheduling files that are already visited
+                        lock (visitedLock)
                         {
-                            var paths = FindPathsInFile(file);
-                            potentialPaths.UnionWith(paths);
-                            ReferencedFiles.UnionWith(paths);
+                            if (visited.Contains(file))
+                                return;
                         }
-                        catch (Exception ex)
-                        {
-                            #if DEBUG
-                            Console.Error.WriteLine($"Unable to parse {ReplaceControlChars(file)}: " +
-                                $"{ex.GetType().Name}: {ex.Message.Trim()}");
-                            #endif
-                        }
+                        filesToProcess.Add(file);
                     },
                     (_) => { }
-                    );
+                );
             }
-            return potentialPaths;
+
+            var bag = new ConcurrentBag<string>();
+            var options = new ParallelOptions { MaxDegreeOfParallelism = Math.Max(1, readerPoolSize) };
+            Parallel.ForEach(filesToProcess, options, file =>
+            {
+                try
+                {
+                    var paths = FindPathsInFile(file);
+                    foreach (var p in paths)
+                    {
+                        bag.Add(p);
+                    }
+                    lock (referencedFilesLock)
+                    {
+                        ReferencedFiles.UnionWith(paths);
+                    }
+                }
+                #if DEBUG
+                catch (Exception ex)
+                #else
+                catch (Exception)
+                #endif
+                {
+                    #if DEBUG
+                    Console.Error.WriteLine($"Unable to parse {ReplaceControlChars(file)}: " +
+                        $"{ex.GetType().Name}: {ex.Message.Trim()}");
+                    #endif
+                }
+            });
+
+            return new PotentialPaths(bag);
         }
 
         /// <summary>
@@ -305,11 +615,17 @@ namespace Extractor.Deep
         /// set is returned.</returns>
         private HashSet<string> FindPathsInFile(string filePath)
         {
-            visited.Add(filePath);
-
-            if (junkEntries.ContainsKey(reader.HashPath(filePath)))
+            lock (visitedLock)
             {
-                return [];
+                visited.Add(filePath);
+            }
+
+            lock (junkEntriesLock)
+            {
+                if (junkEntries.ContainsKey(reader.HashPath(filePath)))
+                {
+                    return [];
+                }
             }
 
             if (!reader.FileExists(filePath))
@@ -317,9 +633,15 @@ namespace Extractor.Deep
                 return [];
             }
 
-            FoundFiles.Add(filePath);
+            lock (foundFilesLock)
+            {
+                FoundFiles.Add(filePath);
+            }
             var fileEntry = reader.GetEntry(filePath);
-            visitedEntries.Add(fileEntry);
+            lock (visitedEntriesLock)
+            {
+                visitedEntries.Add(fileEntry);
+            }
             AddDirToDirsToSearchForRelativeTobj(filePath);
 
             // skip HashFS v2 tobj/dds entries because we don't need to scan those
@@ -334,12 +656,70 @@ namespace Extractor.Deep
                 return [];
             }
 
-            var fileBuffer = reader.Extract(fileEntry, filePath)[0];
+            var swExt = Stopwatch.StartNew();
+            byte[] fileBuffer;
+            if (readerPool is null)
+            {
+                lock (readerLock)
+                {
+                    MarkDecompWallStart();
+                    fileBuffer = reader.Extract(fileEntry, filePath)[0];
+                    MarkDecompWallEnd();
+                }
+            }
+            else
+            {
+                IHashFsReader r = null;
+                try
+                {
+                    r = AcquireReader();
+                    MarkDecompWallStart();
+                    fileBuffer = r.Extract(fileEntry, filePath)[0];
+                    MarkDecompWallEnd();
+                }
+                finally
+                {
+                    ReleaseReader(r);
+                }
+            }
+            swExt.Stop();
+            System.Threading.Interlocked.Add(ref extractTicks, swExt.ElapsedTicks);
+            System.Threading.Interlocked.Add(ref bytesInflated, fileBuffer.LongLength);
             if (fileType == FileType.Unknown)
             {
                 fileType = FileTypeHelper.Infer(fileBuffer);
             }
-            return fpf.FindPathsInFile(fileBuffer, filePath, fileType);
+            var swParse = Stopwatch.StartNew();
+            var result = fpf.FindPathsInFile(fileBuffer, filePath, fileType);
+            swParse.Stop();
+            System.Threading.Interlocked.Add(ref parseTicks, swParse.ElapsedTicks);
+            System.Threading.Interlocked.Increment(ref filesParsed);
+            uniqueParsed.TryAdd(filePath ?? string.Empty, 0);
+            return result;
+        }
+
+        private void MarkDecompWallStart()
+        {
+            var now = Stopwatch.GetTimestamp();
+            lock (decompWallLock)
+            {
+                if (decompWallStartTs == 0 || now < decompWallStartTs)
+                {
+                    decompWallStartTs = now;
+                }
+            }
+        }
+
+        private void MarkDecompWallEnd()
+        {
+            var now = Stopwatch.GetTimestamp();
+            lock (decompWallLock)
+            {
+                if (now > decompWallEndTs)
+                {
+                    decompWallEndTs = now;
+                }
+            }
         }
 
         private void AddDirToDirsToSearchForRelativeTobj(string filePath)
@@ -348,7 +728,10 @@ namespace Extractor.Deep
             {
                 if (filePath.StartsWith(root))
                 {
-                    dirsToSearchForRelativeTobj.Add(GetParent(filePath));
+                    lock (dirsLock)
+                    {
+                        dirsToSearchForRelativeTobj.Add(GetParent(filePath));
+                    }
                 }
             }
         }

--- a/Extractor/Deep/PotentialPaths.cs
+++ b/Extractor/Deep/PotentialPaths.cs
@@ -37,6 +37,58 @@ namespace Extractor.Deep
             }
         }
 
+        /// <summary>
+        /// Adds a path and common variant paths (e.g., related material/tobj/dds files),
+        /// without consulting any external visited set. Caller should de-duplicate later.
+        /// </summary>
+        /// <param name="path">The path to add.</param>
+        public void AddWithVariants(string path)
+        {
+            if (!ResemblesPath(path))
+                return;
+
+            EnsureHasInitialSlash(ref path);
+
+            if (!Add(path))
+                return;
+
+            var extension = Path.GetExtension(path);
+
+            if (extension == ".pmd")
+            {
+                Add(Path.ChangeExtension(path, ".pmg"));
+                Add(Path.ChangeExtension(path, ".pmc"));
+                Add(Path.ChangeExtension(path, ".pma"));
+                Add(Path.ChangeExtension(path, ".ppd"));
+            }
+            else if (extension == ".pmg")
+            {
+                Add(Path.ChangeExtension(path, ".pmd"));
+                Add(Path.ChangeExtension(path, ".pmc"));
+                Add(Path.ChangeExtension(path, ".pma"));
+                Add(Path.ChangeExtension(path, ".ppd"));
+            }
+            else if (extension == ".bank")
+            {
+                Add(Path.ChangeExtension(path, ".bank.guids"));
+            }
+            else if (extension == ".mat")
+            {
+                Add(Path.ChangeExtension(path, ".tobj"));
+                Add(Path.ChangeExtension(path, ".dds"));
+            }
+            else if (extension == ".tobj")
+            {
+                Add(Path.ChangeExtension(path, ".mat"));
+                Add(Path.ChangeExtension(path, ".dds"));
+            }
+            else if (extension == ".dds")
+            {
+                Add(Path.ChangeExtension(path, ".mat"));
+                Add(Path.ChangeExtension(path, ".tobj"));
+            }
+        }
+
         private void AddPathVariants(string path, HashSet<string> visited)
         {
             var extension = Path.GetExtension(path);

--- a/Extractor/Deep/ZipPathFinder.cs
+++ b/Extractor/Deep/ZipPathFinder.cs
@@ -31,7 +31,7 @@ namespace Extractor.Deep
         {
             this.reader = reader;
             ReferencedFiles = [];
-            fpf = new FilePathFinder([], ReferencedFiles, [], reader);
+            fpf = new FilePathFinder(ReferencedFiles, [], reader, new object(), new object());
         }
 
         /// <summary>

--- a/Extractor/Extractor.cs
+++ b/Extractor/Extractor.cs
@@ -22,9 +22,59 @@ namespace Extractor
         public bool Overwrite { get; set; } = true;
 
         /// <summary>
+        /// If true, skip writing files to disk during extraction.
+        /// </summary>
+        public bool DryRun { get; set; } = false;
+
+        /// <summary>
         /// The absolute path of the archive file.
         /// </summary>
         public string ScsPath { get; init; }
+
+        /// <summary>
+        /// Timing: time spent opening the archive.
+        /// </summary>
+        public TimeSpan? OpenTime { get; set; }
+
+        /// <summary>
+        /// Timing: time spent searching for paths (when applicable).
+        /// </summary>
+        public TimeSpan? SearchTime { get; set; }
+
+        /// <summary>
+        /// Timing: time spent extracting files.
+        /// </summary>
+        public TimeSpan? ExtractTime { get; set; }
+
+        /// <summary>
+        /// Timing detail: time spent in search while decompressing/reading entries.
+        /// </summary>
+        public TimeSpan? SearchExtractTime { get; set; }
+
+        /// <summary>
+        /// Timing detail: time spent in search while parsing entries.
+        /// </summary>
+        public TimeSpan? SearchParseTime { get; set; }
+
+        /// <summary>
+        /// Detail: number of files parsed during search.
+        /// </summary>
+        public int? SearchFilesParsed { get; set; }
+
+        /// <summary>
+        /// Detail: total decompressed bytes read during search.
+        /// </summary>
+        public long? SearchBytesInflated { get; set; }
+
+        /// <summary>
+        /// Detail: wall-clock time window spent performing IO/decompression during search.
+        /// </summary>
+        public TimeSpan? SearchExtractWallTime { get; set; }
+
+        /// <summary>
+        /// Detail: unique files parsed during search.
+        /// </summary>
+        public int? SearchUniqueFilesParsed { get; set; }
 
         /// <summary>
         /// Files which were renamed because they contained invalid characters.
@@ -91,6 +141,8 @@ namespace Extractor
 
         protected void WriteRenamedSummary(string outputRoot)
         {
+            if (DryRun)
+                return;
             if (renamedFiles.Count == 0)
                 return;
 
@@ -106,6 +158,8 @@ namespace Extractor
 
         protected void WriteModifiedSummary(string outputRoot)
         {
+            if (DryRun)
+                return;
             if (modifiedFiles.Count == 0)
                 return;
 

--- a/Extractor/Extractor.cs
+++ b/Extractor/Extractor.cs
@@ -77,6 +77,11 @@ namespace Extractor
         public int? SearchUniqueFilesParsed { get; set; }
 
         /// <summary>
+        /// Whether to include timing in output (set from --times).
+        /// </summary>
+        public bool PrintTimesEnabled { get; set; } = false;
+
+        /// <summary>
         /// Files which were renamed because they contained invalid characters.
         /// </summary>
         protected List<(string ArchivePath, string SanitizedPath)> renamedFiles = [];
@@ -174,3 +179,4 @@ namespace Extractor
         }
     }
 }
+

--- a/Extractor/HashFsExtractor.cs
+++ b/Extractor/HashFsExtractor.cs
@@ -431,16 +431,33 @@ namespace Extractor
 
         public override void PrintExtractionResult()
         {
-            var times = (OpenTime.HasValue || SearchTime.HasValue || ExtractTime.HasValue)
-                ? $" | open={OpenTime?.TotalMilliseconds:F0}ms" +
-                  (SearchTime.HasValue
-                    ? $", search={SearchTime?.TotalMilliseconds:F0}ms" +
-                      (SearchExtractTime.HasValue || SearchParseTime.HasValue || SearchFilesParsed.HasValue || SearchBytesInflated.HasValue
-                        ? $" (decomp={SearchExtractTime?.TotalMilliseconds:F0}ms, parse={SearchParseTime?.TotalMilliseconds:F0}ms, files={SearchFilesParsed?.ToString() ?? "-"}, bytes={SearchBytesInflated?.ToString() ?? "-"})"
-                        : string.Empty)
-                    : string.Empty)
-                  + $", extract={ExtractTime?.TotalMilliseconds:F0}ms"
-                : string.Empty;
+            string times = string.Empty;
+            if (PrintTimesEnabled)
+            {
+                var parts = new List<string>();
+                if (OpenTime.HasValue) parts.Add($"open={OpenTime.Value.TotalMilliseconds:F0}ms");
+                if (SearchTime.HasValue)
+                {
+                    var search = $"search={SearchTime.Value.TotalMilliseconds:F0}ms";
+                    var details = new List<string>();
+                    if (SearchExtractTime.HasValue) details.Add($"decomp={SearchExtractTime.Value.TotalMilliseconds:F0}ms");
+                    if (SearchExtractWallTime.HasValue) details.Add($"decomp_wall={SearchExtractWallTime.Value.TotalMilliseconds:F0}ms");
+                    if (SearchParseTime.HasValue) details.Add($"parse={SearchParseTime.Value.TotalMilliseconds:F0}ms");
+                    if (SearchFilesParsed.HasValue) details.Add($"files={SearchFilesParsed.Value}");
+                    if (SearchUniqueFilesParsed.HasValue) details.Add($"unique={SearchUniqueFilesParsed.Value}");
+                    if (SearchBytesInflated.HasValue) details.Add($"bytes={SearchBytesInflated.Value}");
+                    if (details.Count > 0)
+                    {
+                        search += " (" + string.Join(", ", details) + ")";
+                    }
+                    parts.Add(search);
+                }
+                if (ExtractTime.HasValue) parts.Add($"extract={ExtractTime.Value.TotalMilliseconds:F0}ms");
+                if (parts.Count > 0)
+                {
+                    times = " | " + string.Join(", ", parts);
+                }
+            }
             Console.Error.WriteLine($"{extracted} extracted " +
                 $"({renamedFiles.Count} renamed, {modifiedFiles.Count} modified), " +
                 $"{skipped} skipped, {notFound} not found, {duplicate} junk, {failed} failed" +
@@ -528,3 +545,4 @@ namespace Extractor
         }
     }
 }
+

--- a/Extractor/Options.cs
+++ b/Extractor/Options.cs
@@ -29,6 +29,11 @@ namespace Extractor
         public string Destination { get; set; } = "./extracted";
         public ushort? Salt { get; set; } = null;
         public bool Separate { get; set; } = false;
+        public bool SingleThread { get; set; } = false;
+        public bool Times { get; set; } = false;
+        public bool DryRun { get; set; } = false;
+        public bool Benchmark { get; set; } = false;
+        public int IoReaders { get; set; } = 0; // 0 = auto
 
         public Options()
         {
@@ -89,6 +94,21 @@ namespace Extractor
                     "Prints the directory tree and exits. Can be combined with " +
                     "-deep, --partial, --paths,\nand --all.",
                     x => { PrintTree = true; } },
+                { "single-thread",
+                    "Force single-threaded path search (slower, legacy behavior).",
+                    x => { SingleThread = true; } },
+                { "times",
+                    "Print timing for open, search, and extraction stages.",
+                    x => { Times = true; } },
+                { "dry-run",
+                    "Run without writing files (skips actual extraction).",
+                    x => { DryRun = true; } },
+                { "benchmark",
+                    "Run a dry-run deep scan twice (single-thread and multi-thread) and compare timings.",
+                    x => { Benchmark = true; Times = true; UseDeepExtractor = true; } },
+                { "io-readers=",
+                    "[HashFS + --deep] Number of parallel readers to use for IO/decompression (default: number of logical CPUs).",
+                    x => { if (int.TryParse(x, out var n)) IoReaders = Math.Max(0, n); } },
                 { "?|h|help",
                     $"Prints this message and exits.",
                     x => { PrintHelp = true; } },

--- a/Extractor/Options.cs
+++ b/Extractor/Options.cs
@@ -34,6 +34,7 @@ namespace Extractor
         public bool DryRun { get; set; } = false;
         public bool Benchmark { get; set; } = false;
         public int IoReaders { get; set; } = 0; // 0 = auto
+        public bool LegacySanitize { get; set; } = false;
 
         public Options()
         {
@@ -109,6 +110,9 @@ namespace Extractor
                 { "io-readers=",
                     "[HashFS + --deep] Number of parallel readers to use for IO/decompression (default: number of logical CPUs).",
                     x => { if (int.TryParse(x, out var n)) IoReaders = Math.Max(0, n); } },
+                { "legacy-sanitize",
+                    "Use legacy replacement for invalid chars (xNN hex). Disables whole-name counter rule.",
+                    x => { LegacySanitize = true; } },
                 { "?|h|help",
                     $"Prints this message and exits.",
                     x => { PrintHelp = true; } },
@@ -150,3 +154,4 @@ namespace Extractor
         }
     }
 }
+

--- a/Extractor/Program.cs
+++ b/Extractor/Program.cs
@@ -35,6 +35,9 @@ namespace Extractor
             opt = new Options();
             opt.Parse(args);
 
+            // Configure sanitization behavior
+            PathUtils.LegacyReplaceMode = opt.LegacySanitize;
+
             if (opt.PrintHelp || args.Length == 0)
             {
                 Console.WriteLine($"Extractor {Version}\n");
@@ -85,6 +88,7 @@ namespace Extractor
                     continue;
 
                 extractor.DryRun = opt.DryRun;
+                extractor.PrintTimesEnabled = opt.Times;
                 if (extractor is HashFsDeepExtractor hdeep)
                 {
                     hdeep.SingleThreadedPathSearch = opt.SingleThread;
@@ -223,6 +227,7 @@ namespace Extractor
                 if (extractor is not null)
                 {
                     extractor.DryRun = opt.DryRun;
+                    extractor.PrintTimesEnabled = opt.Times;
                     if (extractor is HashFsDeepExtractor hd)
                     {
                         hd.SingleThreadedPathSearch = opt.SingleThread;
@@ -498,4 +503,5 @@ namespace Extractor
         }
     }
 }
+
 

--- a/Extractor/Program.cs
+++ b/Extractor/Program.cs
@@ -406,13 +406,13 @@ namespace Extractor
                 void PrintBench(string title, HashFsDeepExtractor e, int found)
                 {
                     Console.WriteLine(
-                        $"  {title}: search={e.SearchTime?.TotalMilliseconds:F0}ms " +
-                        $"(decomp={e.SearchExtractTime?.TotalMilliseconds:F0}ms, " +
-                        $"decomp_wall={e.SearchExtractWallTime?.TotalMilliseconds:F0}ms, " +
-                        $"parse={e.SearchParseTime?.TotalMilliseconds:F0}ms, " +
-                        $"files={e.SearchFilesParsed?.ToString() ?? "-"}, " +
-                        $"unique={e.SearchUniqueFilesParsed?.ToString() ?? "-"}, " +
-                        $"bytes={e.SearchBytesInflated?.ToString() ?? "-"}), " +
+                        $"  {title}: search={e.SearchTime.Value.TotalMilliseconds:F0}ms " +
+                        $"(decomp={e.SearchExtractTime.Value.TotalMilliseconds:F0}ms, " +
+                        $"decomp_wall={e.SearchExtractWallTime.Value.TotalMilliseconds:F0}ms, " +
+                        $"parse={e.SearchParseTime.Value.TotalMilliseconds:F0}ms, " +
+                        $"files={e.SearchFilesParsed.Value}, " +
+                        $"unique={e.SearchUniqueFilesParsed.Value}, " +
+                        $"bytes={e.SearchBytesInflated.Value}), " +
                         $"found={found}");
                 }
 

--- a/Extractor/Program.cs
+++ b/Extractor/Program.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using static Extractor.PathUtils;
 
 namespace Extractor
@@ -63,6 +64,12 @@ namespace Extractor
                 return;
             }
 
+            if (opt.Benchmark)
+            {
+                RunBenchmark(scsPaths);
+                return;
+            }
+
             if (opt.UseDeepExtractor && scsPaths.Length > 1)
             {
                 DoMultiDeepExtraction(scsPaths);
@@ -71,9 +78,25 @@ namespace Extractor
 
             foreach (var scsPath in scsPaths)
             {
+                var swOpen = Stopwatch.StartNew();
                 var extractor = CreateExtractor(scsPath);
+                swOpen.Stop();
                 if (extractor is null)
                     continue;
+
+                extractor.DryRun = opt.DryRun;
+                if (extractor is HashFsDeepExtractor hdeep)
+                {
+                    hdeep.SingleThreadedPathSearch = opt.SingleThread;
+                    if (!opt.SingleThread)
+                    {
+                        hdeep.ReaderPoolSize = opt.IoReaders > 0 ? opt.IoReaders : Math.Max(1, Environment.ProcessorCount);
+                    }
+                }
+                if (opt.Times)
+                {
+                    extractor.OpenTime = swOpen.Elapsed;
+                }
 
                 if (opt.ListEntries)
                 {
@@ -105,7 +128,37 @@ namespace Extractor
                 }
                 else
                 {
-                    extractor.Extract(opt.PathFilter, GetDestination(scsPath));
+                    if (extractor is HashFsDeepExtractor hde)
+                    {
+                        if (opt.Times)
+                        {
+                            Console.WriteLine("Searching for paths ...");
+                            var swSearch = Stopwatch.StartNew();
+                            var (found, _) = hde.FindPaths();
+                            extractor.SearchTime = swSearch.Elapsed;
+                            var foundFiles = found.Order().ToArray();
+                            var swExtract = Stopwatch.StartNew();
+                            hde.Extract(foundFiles, opt.PathFilter, GetDestination(scsPath), false);
+                            extractor.ExtractTime = swExtract.Elapsed;
+                        }
+                        else
+                        {
+                            hde.Extract(opt.PathFilter, GetDestination(scsPath));
+                        }
+                    }
+                    else
+                    {
+                        if (opt.Times)
+                        {
+                            var swExtract = Stopwatch.StartNew();
+                            extractor.Extract(opt.PathFilter, GetDestination(scsPath));
+                            extractor.ExtractTime = swExtract.Elapsed;
+                        }
+                        else
+                        {
+                            extractor.Extract(opt.PathFilter, GetDestination(scsPath));
+                        }
+                    }
                     extractor.PrintExtractionResult();
                 }
             }
@@ -136,14 +189,7 @@ namespace Extractor
                 // Check if the file begins with "SCS#", the magic bytes of a HashFS file.
                 // Anything else is assumed to be a ZIP file because simply checking for "PK"
                 // would miss ZIP files with invalid local file headers.
-                char[] magic;
-                using (var fs = File.OpenRead(scsPath))
-                using (var r = new BinaryReader(fs, Encoding.ASCII))
-                {
-                    magic = r.ReadChars(4);
-                }
-
-                if (magic.SequenceEqual(['S', 'C', 'S', '#']))
+                if (IsHashFs(scsPath))
                 {
                     extractor = CreateHashFsExtractor(scsPath);
                 }
@@ -168,37 +214,82 @@ namespace Extractor
             // If you're reading this ... maybe don't.
 
             List<Extractor> extractors = [];
+            var openTimes = new Dictionary<string, TimeSpan>();
             foreach (var scsPath in scsPaths)
             {
+                var swOpen = Stopwatch.StartNew();
                 var extractor = CreateExtractor(scsPath);
+                swOpen.Stop();
                 if (extractor is not null)
+                {
+                    extractor.DryRun = opt.DryRun;
+                    if (extractor is HashFsDeepExtractor hd)
+                    {
+                        hd.SingleThreadedPathSearch = opt.SingleThread;
+                        if (!opt.SingleThread)
+                        {
+                            hd.ReaderPoolSize = opt.IoReaders > 0 ? opt.IoReaders : Math.Max(1, Environment.ProcessorCount);
+                        }
+                    }
                     extractors.Add(extractor);
+                    openTimes[extractor.ScsPath] = swOpen.Elapsed;
+                    if (opt.Times)
+                    {
+                        extractor.OpenTime = swOpen.Elapsed;
+                    }                    
+                }
             }
 
-            HashSet<string> everything = [];
-            foreach (var extractor in extractors)
+            var bag = new System.Collections.Concurrent.ConcurrentBag<string>();
+            Parallel.ForEach(extractors, extractor =>
             {
                 Console.WriteLine($"Searching for paths in {Path.GetFileName(extractor.ScsPath)} ...");
                 if (extractor is HashFsDeepExtractor hashFs)
                 {
+                    var swSearch = Stopwatch.StartNew();
                     var (found, referenced) = hashFs.FindPaths();
-                    everything.UnionWith(found);
-                    everything.UnionWith(referenced);
+                    swSearch.Stop();
+                    if (opt.Times)
+                    {
+                        extractor.SearchTime = swSearch.Elapsed;
+                    }
+                    foreach (var p in found)
+                    {
+                        bag.Add(p);
+                    }
+                    foreach (var p in referenced)
+                    {
+                        bag.Add(p);
+                    }
                 }
                 else if (extractor is ZipExtractor zip)
                 {
                     var finder = new ZipPathFinder(zip.Reader);
+                    var swSearch = Stopwatch.StartNew();
                     finder.Find();
-                    var paths = finder.ReferencedFiles
-                        .Union(zip.Reader.Entries.Keys.Select(p => '/' + p));
-                    everything.UnionWith(paths);
+                    swSearch.Stop();
+                    if (opt.Times)
+                    {
+                        extractor.SearchTime = swSearch.Elapsed;
+                    }
+                    foreach (var p in finder.ReferencedFiles)
+                    {
+                        bag.Add(p);
+                    }
+                    foreach (var p in zip.Reader.Entries.Keys.Select(p => '/' + p))
+                    {
+                        bag.Add(p);
+                    }
                 }
                 else
                 {
                     throw new ArgumentException("Unhandled extractor type");
                 }
-            }
+            });
 
+            var everything = new HashSet<string>(bag);
+
+            var extractTimes = new Dictionary<string, TimeSpan>();
             foreach (var extractor in extractors)
             {
                 var existing = everything.Where(extractor.FileSystem.FileExists);
@@ -221,11 +312,23 @@ namespace Extractor
                 {
                     if (extractor is HashFsDeepExtractor hashFs)
                     {
+                        var swExtract = Stopwatch.StartNew();
                         hashFs.Extract(existing.ToArray(), opt.PathFilter, GetDestination(extractor.ScsPath), true);
+                        extractTimes[extractor.ScsPath] = swExtract.Elapsed;
+                        if (opt.Times)
+                        {
+                            extractor.ExtractTime = swExtract.Elapsed;
+                        }
                     }
                     else
                     {
+                        var swExtract = Stopwatch.StartNew();
                         extractor.Extract(opt.PathFilter, GetDestination(extractor.ScsPath));
+                        extractTimes[extractor.ScsPath] = swExtract.Elapsed;
+                        if (opt.Times)
+                        {
+                            extractor.ExtractTime = swExtract.Elapsed;
+                        }
                     }
                 }
             }
@@ -237,6 +340,89 @@ namespace Extractor
                     Console.Write($"{Path.GetFileName(extractor.ScsPath)}: ");
                     extractor.PrintExtractionResult();
                 }
+            }
+        }
+
+        private static bool IsHashFs(string scsPath)
+        {
+            try
+            {
+                using var fs = File.OpenRead(scsPath);
+                using var r = new BinaryReader(fs, Encoding.ASCII);
+                var magic = r.ReadChars(4);
+                return magic.SequenceEqual(['S','C','S','#']);
+            }
+            catch { return false; }
+        }
+
+        private static void RunBenchmark(string[] scsPaths)
+        {
+            foreach (var scsPath in scsPaths)
+            {
+                if (!IsHashFs(scsPath))
+                {
+                    Console.Error.WriteLine($"Benchmark: skipping {Path.GetFileName(scsPath)} (not a HashFS archive)");
+                    continue;
+                }
+
+                Console.WriteLine($"Benchmarking {Path.GetFileName(scsPath)} (deep scan, dry-run) ...");
+
+                HashFsDeepExtractor MakeExtractor(bool singleThread)
+                {
+                    var x = new HashFsDeepExtractor(scsPath, overwrite: !opt.SkipIfExists, opt.Salt)
+                    {
+                        ForceEntryTableAtEnd = opt.ForceEntryTableAtEnd,
+                        PrintNotFoundMessage = !opt.ExtractAllInDir,
+                        AdditionalStartPaths = opt.AdditionalStartPaths,
+                        SingleThreadedPathSearch = singleThread,
+                        DryRun = true,
+                    };
+                    if (!singleThread && opt.IoReaders > 0)
+                    {
+                        x.ReaderPoolSize = Math.Max(1, opt.IoReaders);
+                    }
+                    return x;
+                }
+
+                // Single-thread pass
+                var single = MakeExtractor(true);
+                var swSingle = Stopwatch.StartNew();
+                var (foundSingle, _) = single.FindPaths();
+                swSingle.Stop();
+                single.SearchTime = swSingle.Elapsed; // already set inside, but ensure measured wall time
+
+                // Multi-thread pass
+                var multi = MakeExtractor(false);
+                var swMulti = Stopwatch.StartNew();
+                var (foundMulti, _) = multi.FindPaths();
+                swMulti.Stop();
+                multi.SearchTime = swMulti.Elapsed;
+
+                void PrintBench(string title, HashFsDeepExtractor e, int found)
+                {
+                    Console.WriteLine(
+                        $"  {title}: search={e.SearchTime?.TotalMilliseconds:F0}ms " +
+                        $"(decomp={e.SearchExtractTime?.TotalMilliseconds:F0}ms, " +
+                        $"decomp_wall={e.SearchExtractWallTime?.TotalMilliseconds:F0}ms, " +
+                        $"parse={e.SearchParseTime?.TotalMilliseconds:F0}ms, " +
+                        $"files={e.SearchFilesParsed?.ToString() ?? "-"}, " +
+                        $"unique={e.SearchUniqueFilesParsed?.ToString() ?? "-"}, " +
+                        $"bytes={e.SearchBytesInflated?.ToString() ?? "-"}), " +
+                        $"found={found}");
+                }
+
+                PrintBench("single-thread", single, foundSingle.Count);
+                PrintBench("multi-thread", multi, foundMulti.Count);
+
+                if (single.SearchTime.HasValue && multi.SearchTime.HasValue)
+                {
+                    var speedup = single.SearchTime.Value.TotalMilliseconds / Math.Max(1, multi.SearchTime.Value.TotalMilliseconds);
+                    Console.WriteLine($"  speedup: x{speedup:F2}");
+                }
+
+                // Dispose
+                single.Dispose();
+                multi.Dispose();
             }
         }
 
@@ -312,3 +498,4 @@ namespace Extractor
         }
     }
 }
+

--- a/Extractor/Zip/ZipExtractor.cs
+++ b/Extractor/Zip/ZipExtractor.cs
@@ -64,7 +64,10 @@ namespace Extractor.Zip
             {
                 try
                 {
-                    PrintExtractionMessage(entry.FileName, scsName);
+                    if (!DryRun)
+                    {
+                        PrintExtractionMessage(entry.FileName, scsName);
+                    }
                     if (!substitutions.TryGetValue(entry.FileName, out string fileName))
                     {
                         fileName = entry.FileName;
@@ -141,6 +144,12 @@ namespace Extractor.Zip
                 renamedFiles.Add((entry.FileName, fileName));
             }
 
+            if (DryRun)
+            {
+                extracted++;
+                return;
+            }
+
             var outputDir = Path.GetDirectoryName(outputPath);
             if (outputDir != null)
             {
@@ -165,9 +174,14 @@ namespace Extractor.Zip
 
         public override void PrintExtractionResult()
         {
+            var times = (OpenTime.HasValue || SearchTime.HasValue || ExtractTime.HasValue)
+                ? $" | open={OpenTime?.TotalMilliseconds:F0}ms, " +
+                  $"search={SearchTime?.TotalMilliseconds:F0}ms, " +
+                  $"extract={ExtractTime?.TotalMilliseconds:F0}ms"
+                : string.Empty;
             Console.Error.WriteLine($"{extracted} extracted " +
                 $"({renamedFiles.Count} renamed, {modifiedFiles.Count} modified), " +
-                $"{skipped} skipped, {failed} failed");
+                $"{skipped} skipped, {failed} failed" + times);
             PrintRenameSummary(renamedFiles.Count, modifiedFiles.Count);
         }
 

--- a/Extractor/Zip/ZipExtractor.cs
+++ b/Extractor/Zip/ZipExtractor.cs
@@ -64,14 +64,11 @@ namespace Extractor.Zip
             {
                 try
                 {
-                    if (!DryRun)
-                    {
-                        PrintExtractionMessage(entry.FileName, scsName);
-                    }
                     if (!substitutions.TryGetValue(entry.FileName, out string fileName))
-                    {
                         fileName = entry.FileName;
-                    }
+
+                    if (!DryRun)
+                        PrintExtractionMessage(entry.FileName, scsName);
                     ExtractEntry(entry, outputRoot, fileName);
                 }
                 catch (Exception ex)
@@ -174,11 +171,18 @@ namespace Extractor.Zip
 
         public override void PrintExtractionResult()
         {
-            var times = (OpenTime.HasValue || SearchTime.HasValue || ExtractTime.HasValue)
-                ? $" | open={OpenTime?.TotalMilliseconds:F0}ms, " +
-                  $"search={SearchTime?.TotalMilliseconds:F0}ms, " +
-                  $"extract={ExtractTime?.TotalMilliseconds:F0}ms"
-                : string.Empty;
+            string times = string.Empty;
+            if (PrintTimesEnabled)
+            {
+                var parts = new List<string>();
+                if (OpenTime.HasValue) parts.Add($"open={OpenTime.Value.TotalMilliseconds:F0}ms");
+                if (SearchTime.HasValue) parts.Add($"search={SearchTime.Value.TotalMilliseconds:F0}ms");
+                if (ExtractTime.HasValue) parts.Add($"extract={ExtractTime.Value.TotalMilliseconds:F0}ms");
+                if (parts.Count > 0)
+                {
+                    times = " | " + string.Join(", ", parts);
+                }
+            }
             Console.Error.WriteLine($"{extracted} extracted " +
                 $"({renamedFiles.Count} renamed, {modifiedFiles.Count} modified), " +
                 $"{skipped} skipped, {failed} failed" + times);
@@ -235,3 +239,4 @@ namespace Extractor.Zip
         }
     }
 }
+

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ extractor path... [options]
 </tr>
 <tr>
   <td></td>
+  <td><code>--legacy-sanitize</code></td>
+  <td>Use legacy invalid-character replacement (<code>xNN</code> hex per char). Disables whole-name counter renaming.</td>
+ </tr>
+<tr>
+  <td></td>
   <td><code>--list-all</code></td>
   <td>Lists all paths referenced by files in the archive, even if they are not contained in it.
   (Implicitly activates <code>--deep</code>.)</td>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ dotnet publish -c Release
 extractor path... [options]
 ```
 
-### General options
+### General Options
 <table>
 <thead>
   <tr>
@@ -41,7 +41,12 @@ extractor path... [options]
 <tr>
   <td><code>-d</code></td>
   <td><code>--dest</code></td>
-  <td>Sets the output directory. Defaults to <code>./extracted</code>.</td>
+  <td>Sets the output directory. Default: <code>./extracted</code>.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><code>--dry-run</code></td>
+  <td>Simulates extraction without writing files to disk.</td>
 </tr>
 <tr>
   <td></td>
@@ -69,8 +74,7 @@ extractor path... [options]
 <tr>
   <td><code>-P</code></td>
   <td><code>--paths</code></td>
-  <td>Same as <code>--partial</code>, but expects a text file containing paths to extract, separated by
-  line breaks.</td>
+  <td>Same as <code>--partial</code>, but expects a text file containing paths to extract, separated by line breaks.</td>
 </tr>
 <tr>
   <td><code>-S</code></td>
@@ -85,8 +89,7 @@ extractor path... [options]
 <tr>
   <td></td>
   <td><code>--tree</code></td>
-  <td>Prints the directory tree and exits. Can be combined with <code>--deep</code>, <code>--partial</code>, 
-  <code>--paths</code>, and <code>--all</code>.</td>
+  <td>Prints the directory tree and exits. Can be combined with <code>--deep</code>, <code>--partial</code>, <code>--paths</code>, and <code>--all</code>.</td>
 </tr>
 <tr>
   <td><code>-?</code>, <code>-h</code></td>
@@ -96,7 +99,7 @@ extractor path... [options]
 </table>
 
 
-### HashFS options
+### HashFS Options
 <table>
 <thead>
   <tr>
@@ -108,14 +111,17 @@ extractor path... [options]
 <tr>
   <td></td>
   <td><code>--additional</code></td>
-  <td>When using <code>--deep</code>, specifies additional start paths to search.
-  Expects a text file containing paths to extract, separated by line breaks.</td>
+  <td>When using <code>--deep</code>, specifies additional start paths to search. Expects a text file containing paths to extract, separated by line breaks.</td>
 </tr>
 <tr>
   <td><code>-D</code></td>
   <td><code>--deep</code></td>
-  <td>An extraction mode which scans the contained entries for referenced paths instead of traversing
-  the directory tree from <code>/</code>. Use this option to extract archives without a top level directory listing.</td>
+  <td>Scans contained entries for referenced paths instead of traversing from <code>/</code>. Use this to extract archives without a top-level directory listing.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><code>--single-thread</code></td>
+  <td>When using <code>--deep</code>, forces single-threaded path search (slower, legacy behavior). Default: multi-threaded.</td>
 </tr>
 <tr>
   <td></td>
@@ -131,7 +137,7 @@ extractor path... [options]
 <tr>
   <td></td>
   <td><code>--salt</code></td>
-  <td>Ignores the salt specified in the archive header and uses the given one instead.</td>
+  <td>Ignores the salt in the archive header and uses the given one instead.</td>
 </tr>
 <tr>
   <td></td>
@@ -177,3 +183,9 @@ Alternatively:
 ```
 extractor "path\to\mod\directory" --all --deep --separate
 ```
+
+## Performance Options
+- <code>--times</code>: Print stage timing summary.
+- <code>--benchmark</code>: Deep-scan benchmark (HashFS, dry-run; single vs multi-thread).
+- <code>--single-thread</code>: Single-threaded deep search (HashFS).
+- <code>--io-readers=N</code>: Number of parallel readers for IO/decompression. Applies only to HashFS with <code>--deep</code>. Default: logical CPU count; set <code>N=0</code> to auto.


### PR DESCRIPTION
### Summary
- Introduces parallel path discovery for HashFS deep scans using a reader pool, significantly speeding up scans on large archives.
- Adds detailed timing and throughput metrics for open/search/extract stages (optional via `--times`).
- Implements a `--dry-run` mode to simulate extraction without writing to disk (great for validation/benchmarking).
- Expands CLI with `--benchmark`, `--single-thread`, and `--io-readers` knobs.
- Improves thread-safety and simplifies path de‑duplication logic during deep scans.
- Updates README with new options and clarifies wording in several places.

### Motivation
Deep scans on HashFS archives can be CPU and IO intensive. This PR parallelizes the search phase while keeping output stable, and surfaces timing/throughput metrics to help users understand performance and choose the best settings for their systems. A dry‑run mode and a simple benchmark flow make it easier to validate behavior and compare single vs multi‑thread runs.

### Key Changes

#### Deep Scan and Concurrency (HashFS)
- Parallel path discovery with a pool of `IHashFsReader` clones (semaphore‑controlled), default size = logical CPU count.
- New constructor for `HashFsPathFinder`: supports `singleThreaded`, `readerFactory`, and `readerPoolSize` to switch between legacy single‑thread and new multi‑thread modes.
- Fine‑grained locks around shared structures: `visited`, `visitedEntries`, `ReferencedFiles`, `FoundFiles`, `dirsToSearchForRelativeTobj`, `junkEntries`, and reader access.
- File extraction during search uses the reader pool when available; otherwise falls back to the single shared reader under a lock.
- Collects metrics during search: decompression CPU time, wall‑clock window for IO/decompression, parse time, files parsed, unique files parsed, and total decompressed bytes.

Files:
- `Extractor/Deep/HashFsPathFinder.cs` (major: threading, reader pool, metrics, locking)
- `Extractor/Deep/HashFsDeepExtractor.cs` (wires options + exposes metrics)

#### Thread‑Safety & De‑duplication Simplification
- `FilePathFinder` no longer consults the caller’s `visited` set. It returns all discovered paths and lets the caller de‑duplicate. This simplifies thread‑safety.
- Added locks for `referencedFiles` and `dirsToSearchForRelativeTobj` updates.

Files:
- `Extractor/Deep/FilePathFinder.cs` (constructor change, locking, variant handling)
- `Extractor/Deep/ZipPathFinder.cs` (updated to new `FilePathFinder` constructor)

#### Path Variant Handling
- New `PotentialPaths.AddWithVariants(path)` adds common related variants without needing an external `visited` set, e.g.:
  - `.mat` ⇄ `.tobj`/`.dds`
  - `.tobj` ⇄ `.mat`/`.dds`
  - `.dds` ⇄ `.mat`/`.tobj`
  - `.pmd`/`.pmg`/`.pmc`/`.pma`/`.ppd`
  - `.bank` → `.bank.guids`

Files:
- `Extractor/Deep/PotentialPaths.cs`
- Used by: `FilePathFinder` in `.mat`, `.font`, `.soundref` parsing.

#### CLI Enhancements
- `--times`: print timing summary for open, search, and extract. Deep scan shows breakdown: `decomp`, `decomp_wall`, `parse`, `files`, `unique`, `bytes`.
- `--dry-run`: skip disk writes and avoid extraction side‑effects; still counts extracted/renamed/modified logically.
- `--benchmark`: run a deep scan dry‑run twice (single‑thread and multi‑thread) and print metrics and speedup.
- `--single-thread`: force legacy single‑thread deep search.
- `--io-readers=N`: number of parallel readers for IO/decompression in deep HashFS scans. Default: logical CPU count. `0` = auto.

Files:
- `Extractor/Options.cs` (new options)
- `Extractor/Program.cs` (wiring, timing, benchmark flow, `IsHashFs` helper)
- `README.md` (docs for new options; wording improvements)

#### Extraction and Reporting
- New `Extractor.DryRun` flag respected by HashFS and ZIP paths:
  - Suppresses file writes and “extracting …” messages.
  - Skips writing `_renamed.txt` and `_modified.txt` summaries.
- `PrintExtractionResult()` now appends timing where available across HashFS, HashFS Deep, and ZIP.

Files:
- `Extractor/Extractor.cs` (DryRun flag; timing properties; avoid summaries on dry‑run)
- `Extractor/HashFsExtractor.cs` (respect DryRun; print timings)
- `Extractor/Zip/ZipExtractor.cs` (respect DryRun; print timings)
- `Extractor/Deep/HashFsDeepExtractor.cs` (DumpUnrecovered respects DryRun; timing summary)

### Behavior Notes
- Default deep scan is now multi‑threaded. Use `--single-thread` to reproduce legacy behavior exactly.
- Search output order remains stable; de‑duplication occurs at the path‑finder level instead of inside `FilePathFinder`.
- `DumpUnrecovered` is skipped in dry‑run mode.
- Exceptions during parsing are logged with details only in DEBUG builds to reduce noise in release runs.

### Performance Expectations
- Multi‑threaded deep scans should be significantly faster on multi‑core systems. Actual speedup depends on IO, compression ratio, CPU, and the chosen `--io-readers` value.
- Use `--benchmark` for a quick single vs multi‑thread comparison on your own archives.

### Benchmark Results
- Using `--benchmark` (deep scan, dry‑run) on a Ryzen Threadripper 7960X, observed speedups from single‑thread to multi‑thread ranged from approximately 1.9× up to 8.0× across the tested mods.
- Results vary by archive content, storage/IO, compression ratios, and the configured `--io-readers`.

### Validation Tips
- Deep scan with timings: `extractor file.scs --deep --times --dry-run`
- Compare modes: `extractor file.scs --benchmark`
- Adjust parallel readers: `extractor file.scs --deep --times --io-readers=4 --dry-run`

### Backward Compatibility
- CLI remains backward‑compatible; new options are additive.
- The default behavior of deep scan changes to multi‑threaded, but `--single-thread` restores the previous behavior.
- Internal constructor/signature changes affect only internal wiring (`FilePathFinder`, `HashFsPathFinder`, `ZipPathFinder`).
