### PR TITLE
Don't wait for a keypress after extraction in quiet mode

### DIFF
--- a/Extractor/Options.cs
+++ b/Extractor/Options.cs
@@ -82,7 +82,8 @@ namespace Extractor
         public bool PrintTree { get; set; } = false;
 
         /// <summary>
-        /// Quiet mode, doesn't print on every extracted file.
+        /// Quiet mode, doesn't print on every extracted file, and doesn't wait
+        /// for a keypress after extraction.
         /// </summary>
         public bool Quiet { get; set; } = false;
 

--- a/Extractor/Program.cs
+++ b/Extractor/Program.cs
@@ -419,7 +419,7 @@ namespace Extractor
 
         private static void PauseIfNecessary()
         {
-            if (launchedByExplorer)
+            if (launchedByExplorer && !opt.Quiet)
             {
                 Console.WriteLine("Press any key to continue ...");
                 Console.Read();

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ extractor path... [options]
 <tr>
   <td><code>-q</code></td>
   <td><code>--quiet</code></td>
-  <td>Don't print paths of extracted files.</td>
+  <td>Don't print paths of extracted files, and don't wait for a keypress after extraction when running outside the command line.</td>
 </tr>
 <tr>
   <td><code>-S</code></td>


### PR DESCRIPTION
This makes quiet mode even quieter by not waiting for a keypress after extraction when not running from the console. (If someone's using quiet mode, they're already in a more advanced use case and not just dragging files onto the .exe in Explorer anyway.)

Context: I'm calling the extractor as an external process from an application, potentially on a lot of files, and currently there's no way around it detecting it's not running from the console and asking for a keypress after each extraction, which would make this pretty annoying for the user. (I could use SCS' own extractor, but I really like the ability to just extract individual files, as I know exactly which ones I need, and they're very small.)

I was originally going to introduce a separate option for this, but then thought it fit the idea of a "quiet mode" pretty well.